### PR TITLE
New post: NBA resting policy

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,6 @@
   "trailingComma": "es5",
   "printWidth": 80,
   "plugins": ["prettier-plugin-svelte"],
-  "pluginSearchDirs": ["."],
   "overrides": [
     {
       "files": "*.svelte",
@@ -20,6 +19,5 @@
     }
   ],
   "bracketSameLine": true,
-  "svelteBracketNewLine": false,
   "bracketSpacing": true
 }

--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  font-family: Roboto, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/lib/assets/posts/nba-rest.md
+++ b/src/lib/assets/posts/nba-rest.md
@@ -1,0 +1,64 @@
+---
+title: WIP NBA Resting Policy
+date: 2023-09-17
+published: false
+---
+
+Last week, the NBA voted on and announced some updates to its
+[player resting policy](espn). There's details in the link but at a high level,
+their goal is to increase player participation in the regular season, especially
+for stars and for nationally televised games. The general reaction from around
+the NBA world seems to be "this makes sense, stars should play". However, I
+think these policy changes are incredibly shortsighted and will certainly lead
+to increased player injuries, which are already [higher than ever](inj). Nothing
+about the NBA's policy changes here considers incentives.
+
+[Incentives](inc) are one of the basic concepts in Economics (and one of the
+only ones I remember from college econ) and are, in my opinion, the most
+important thing driving negotiations like this one. As an example of this,
+consider the US Congress. We, the people, elect Congresspeople with the hope
+that they will serve the country and their constituents. However, the incentive
+structure for Congress doesn't give you anything if you serve your constituents
+effectively. What it _does_ reward is staying in Congress. While you're there,
+you get perks, insider information, donations, access to the rich and powerful;
+the list goes on. And so, the number 1 goal of most people in Congress it to get
+re-elected. And while you might argue that the best way to do that is to serve
+your constituency, that's not the case in practice. Getting re-elected has way
+more to do with the amount of money you raise and the advertising you're able to
+do than anything else. The incentive structure is broken in this scenario.
+
+I believe the NBA's new player rest policies similarly incentivize the wrong
+behavior. If you look at the core of the issue, _why_ are players resting? Is it
+because they don't want to play? No - it's because resting is what's best for
+their health and longevity. The players and the coaches know there are too many
+games for the stars to play ever game, try their best, and be able to have a
+long and successful career.
+
+Nothing about the NBA's rule changes here addresses this fundamental issue.
+They've certainly done some work to [improve the schedule](sch), like reducing
+back-to-backs and travel. But their new player rest policy encourages other
+things. For example, if you have two star players, you now can't rest them both
+in a single game. Given that they need the same amount of rest as last season,
+you are suddenly incentivized to rest those stars every other game. The same
+thing comes from the national TV restriction - if you have to play the national
+games, you're going to sit for the rest.
+
+The new rules are shortsighted and will go badly. My predictions for when this
+policy goes into effect this season:
+
+- Player injuries will rise. The rules allow you to get less rest than before
+  and this will inevitably lead to more injuries.
+- Almost no games that are not national TV or in-seasion tournament will be full
+  strength. If you have to play in the national games, you're going to have to
+  get your rest somewhere. And since you can't rest both stars on the same
+  night, you're going to have to alternate which means someone will almost
+  always be resting.
+- There will be some weird circumstances that generate controversy. For example,
+  it seems that based on the rules, Jamal Murray doesn't count as a star player
+  so he and Jokic can rest whenever they want.
+
+[espn]:
+  https://www.espn.com/nba/story/_/id/38386013/how-nba-new-rules-resting-stars-work
+[inj]: https://journals.sagepub.com/doi/full/10.1177/23259671221121116
+[inc]: https://www.econlib.org/library/Topics/College/incentives.html
+[sch]: https://sports.yahoo.com/nba-limits-back-back-games-161533055.html

--- a/src/lib/assets/posts/nba-rest.md
+++ b/src/lib/assets/posts/nba-rest.md
@@ -1,7 +1,7 @@
 ---
-title: WIP NBA Resting Policy
+title: The NBA doesn't understand the incentives around resting
 date: 2023-09-17
-published: false
+published: true
 ---
 
 Last week, the NBA voted on and announced some updates to its

--- a/src/lib/assets/posts/nba-rest.md
+++ b/src/lib/assets/posts/nba-rest.md
@@ -8,15 +8,16 @@ Last week, the NBA voted on and announced some updates to its
 [player resting policy](espn). There's details in the link but at a high level,
 their goal is to increase player participation in the regular season, especially
 for stars and for nationally televised games. The general reaction from around
-the NBA world seems to be "this makes sense, stars should play". However, I
-think these policy changes are incredibly shortsighted and will certainly lead
-to increased player injuries, which are already [higher than ever](inj). Nothing
-about the NBA's policy changes here considers incentives.
+the NBA world seems to be "this makes sense, stars should play". I'd like to
+make the argument that these policy changes are incredibly shortsighted. They
+will certainly lead to increased player injuries (which are already
+[higher than ever](inj)). Why? Because nothing about the NBA's policy changes
+considers the incentives.
 
 [Incentives](inc) are one of the basic concepts in Economics (and one of the
-only ones I remember from college econ) and are, in my opinion, the most
+only ones I remember from college econ). They are, in my opinion, the most
 important thing driving negotiations like this one. As an example of this,
-consider the US Congress. We, the people, elect Congresspeople with the hope
+consider the US Congress. We, the people, elect Congress members with the hope
 that they will serve the country and their constituents. However, the incentive
 structure for Congress doesn't give you anything if you serve your constituents
 effectively. What it _does_ reward is staying in Congress. While you're there,
@@ -53,9 +54,11 @@ policy goes into effect this season:
   get your rest somewhere. And since you can't rest both stars on the same
   night, you're going to have to alternate which means someone will almost
   always be resting.
-- There will be some weird circumstances that generate controversy. For example,
-  it seems that based on the rules, Jamal Murray doesn't count as a star player
-  so he and Jokic can rest whenever they want.
+- There will be some weird circumstances that generate controversy, like what
+  happened when they tied salary limits to All-NBA and All-Star. There's already
+  been one: the rules don't really affect the Denver Nuggets. Jamal Murray has
+  never made All-Star or All-NBA so he's not considered a "star" by the policy.
+  He and Jokic will be able to totally ignore that part of the new rules.
 
 [espn]:
   https://www.espn.com/nba/story/_/id/38386013/how-nba-new-rules-resting-stars-work

--- a/src/routes/(content)/blog/+page.ts
+++ b/src/routes/(content)/blog/+page.ts
@@ -12,7 +12,9 @@ export const load: PageLoad = async () => {
     if (file && typeof file === "object" && "metadata" in file && slug) {
       const metadata = file.metadata as Omit<Post, "slug">;
       const post = { ...metadata, slug } satisfies Post;
-      post.published && posts.push(post);
+      
+      // List all posts on dev.
+      (import.meta.env.DEV || post.published) && posts.push(post);
     }
   }
 

--- a/src/routes/(content)/blog/+page.ts
+++ b/src/routes/(content)/blog/+page.ts
@@ -12,9 +12,14 @@ export const load: PageLoad = async () => {
     if (file && typeof file === "object" && "metadata" in file && slug) {
       const metadata = file.metadata as Omit<Post, "slug">;
       const post = { ...metadata, slug } satisfies Post;
-      
+
       // List all posts on dev.
-      (import.meta.env.DEV || post.published) && posts.push(post);
+      if (!post.published && import.meta.env.DEV) {
+        post.published = true;
+        post.title = "[wip] " + post.title;
+      }
+
+      post.published && posts.push(post);
     }
   }
 


### PR DESCRIPTION
Also some minor fixes:

- Changed the default font to Roboto. It has a little more weight than Inter and it felt better for reading the blog posts.
- Added some logic to show unpublished posts on dev and prefix them with `[wip]`. 
- Removed some unnecessary Prettier settings.